### PR TITLE
Add support for iOS 11 and 12

### DIFF
--- a/Example/PinwheelSDK.xcodeproj/project.pbxproj
+++ b/Example/PinwheelSDK.xcodeproj/project.pbxproj
@@ -515,6 +515,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = PinwheelSDK/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -530,6 +531,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = PinwheelSDK/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Sources/PinwheelSDK/Classes/Pinwheel.swift
+++ b/Sources/PinwheelSDK/Classes/Pinwheel.swift
@@ -10,6 +10,8 @@ import Foundation
 import UIKit
 import WebKit
 
+fileprivate let linkURL = "https://cdn.getpinwheel.com/link-v2.3.0.html"
+
 public protocol PinwheelDelegate {
     func onEvent(name: PinwheelEventType, event: PinwheelEventPayload?)
     func onExit(_ error: PinwheelError?)
@@ -31,7 +33,6 @@ public class PinwheelViewController: UIViewController, WKUIDelegate, WKScriptMes
     var webView: WKWebView!
     var delegate: PinwheelDelegate
     private var token: String
-    private let linkURL = "https://cdn.getpinwheel.com/link-v2.3.0.html"
     
     public init(token: String, delegate: PinwheelDelegate) {
         self.delegate = delegate
@@ -254,7 +255,8 @@ private func getScript(token: String, initializationTime: Int64) -> String {
                     patch: \(version.count > 2 ? version[2] : "0")
                 }
             }
-          }
+          },
+          "\(linkURL)"
         );
         } catch (err) {
             console.error(err);


### PR DESCRIPTION
## Description of the change

In iOS 11 and 12 Safari's impmentation of `window.posstMessage` requires the second argument.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
