### PR TITLE
Make params and accountId optional for PinwheelSuccessPayload

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -220,8 +220,30 @@ class TableOfContentsSpec: QuickSpec {
                 let payload = delegate.onEventPayload as? PinwheelSuccessPayload
                 expect(payload?.accountId).to(equal("314159"))
                 expect(payload?.job).to(equal("direct_deposit_switch"))
-                expect(payload?.params.amount.unit).to(equal("$"))
-                expect(payload?.params.amount.value).to(equal(3.14159))
+                expect(payload?.params?.amount?.unit).to(equal("$"))
+                expect(payload?.params?.amount?.value).to(equal(3.14159))
+            }
+            
+            it("onEvent is called for success with null values") {
+                let delegate = PinwheelVCDelegate()
+                let userContentController = WKUserContentController()
+                let body: JSONDictionary = [
+                    "type": "PINWHEEL_EVENT",
+                    "eventName": "success",
+                    "payload": [
+                        "accountId": nil,
+                        "job": "direct_deposit_switch",
+                        "params": nil
+                    ]
+                ]
+                let bodyString = asString(jsonDictionary: body)
+                let message = TestMessage("successEventHandler", body: bodyString)
+                let pinwheelVC = PinwheelViewController(token: linkToken, delegate: delegate)
+                pinwheelVC.userContentController(userContentController, didReceive: message)
+                let payload = delegate.onEventPayload as? PinwheelSuccessPayload
+                expect(payload?.accountId).to(beNil())
+                expect(payload?.params).to(beNil())
+                expect(payload?.job).to(equal("direct_deposit_switch"))
             }
             
             it("onEvent is called for error") {
@@ -296,8 +318,8 @@ class TableOfContentsSpec: QuickSpec {
                 pinwheelVC.userContentController(userContentController, didReceive: message)
                 expect(delegate.onSuccessPayload?.accountId).to(equal("314159"))
                 expect(delegate.onSuccessPayload?.job).to(equal("direct_deposit_switch"))
-                expect(delegate.onSuccessPayload?.params.amount.unit).to(equal("$"))
-                expect(delegate.onSuccessPayload?.params.amount.value).to(equal(3.14159))
+                expect(delegate.onSuccessPayload?.params?.amount?.unit).to(equal("$"))
+                expect(delegate.onSuccessPayload?.params?.amount?.value).to(equal(3.14159))
             }
             
             it("onLogin is called") {

--- a/Sources/PinwheelSDK/Classes/Events/PinwheelParams.swift
+++ b/Sources/PinwheelSDK/Classes/Events/PinwheelParams.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public struct PinwheelParams: Codable {
-    public let amount: PinwheelAmountPayload
+    public let amount: PinwheelAmountPayload?
 }

--- a/Sources/PinwheelSDK/Classes/Events/PinwheelSuccessPayload.swift
+++ b/Sources/PinwheelSDK/Classes/Events/PinwheelSuccessPayload.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct PinwheelSuccessPayload: PinwheelEventPayload {
-    public let accountId: String
+    public let accountId: String?
     public let job: String
-    public let params: PinwheelParams
+    public let params: PinwheelParams?
 }


### PR DESCRIPTION
## Description of the change

When the event payload comes through with these values set to null, deserialization fails, and the event is not called. This PR makes them optional fields.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [PP-5213](https://pinwheel.atlassian.net/browse/PP-5213) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
