### PR TITLE
Make account id required

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Nimble (9.0.1)
-  - PinwheelSDK (2.3.3)
+  - PinwheelSDK (2.3.5)
   - Quick (1.2.0)
 
 DEPENDENCIES:
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
-  PinwheelSDK: dbba53b6d44c5c469f0a4c19629fda361de5c93c
+  PinwheelSDK: 2baacb38fa6ab60a8e44487b2550fc46af746b74
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
 
 PODFILE CHECKSUM: 2398613c0d77eaf628905b1b0cc4543ffbee0f79

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -231,7 +231,7 @@ class TableOfContentsSpec: QuickSpec {
                     "type": "PINWHEEL_EVENT",
                     "eventName": "success",
                     "payload": [
-                        "accountId": nil,
+                        "accountId": "314159",
                         "job": "direct_deposit_switch",
                         "params": nil
                     ]
@@ -241,7 +241,7 @@ class TableOfContentsSpec: QuickSpec {
                 let pinwheelVC = PinwheelViewController(token: linkToken, delegate: delegate)
                 pinwheelVC.userContentController(userContentController, didReceive: message)
                 let payload = delegate.onEventPayload as? PinwheelSuccessPayload
-                expect(payload?.accountId).to(beNil())
+                expect(payload?.accountId).to(equal("314159"))
                 expect(payload?.params).to(beNil())
                 expect(payload?.job).to(equal("direct_deposit_switch"))
             }

--- a/Sources/PinwheelSDK/Classes/Events/PinwheelSuccessPayload.swift
+++ b/Sources/PinwheelSDK/Classes/Events/PinwheelSuccessPayload.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct PinwheelSuccessPayload: PinwheelEventPayload {
-    public let accountId: String?
+    public let accountId: String
     public let job: String
     public let params: PinwheelParams?
 }


### PR DESCRIPTION
## Description of the change

We can now make the accountId field in the success payload required due to changes in the Link modal.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) 

## Checklists

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
