### PR TITLE
Release 2.3.6

### DIFF
--- a/PinwheelSDK.podspec
+++ b/PinwheelSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PinwheelSDK'
-  s.version          = '2.3.5'
+  s.version          = '2.3.6'
   s.summary          = 'Pinwheel iOS SDK'
   s.swift_version    = '5.0'
 

--- a/Sources/PinwheelSDK/Classes/Pinwheel.swift
+++ b/Sources/PinwheelSDK/Classes/Pinwheel.swift
@@ -200,7 +200,7 @@ private enum PinwheelEventHandler: String {
 }
 
 private func getScript(token: String, initializationTime: Int64) -> String {
-    var versionString = "2.3.5"
+    var versionString = "2.3.6"
     if let bundleVersion = Bundle(identifier: "org.cocoapods.PinwheelSDK")?.infoDictionary?["CFBundleShortVersionString"] as? String {
         print(bundleVersion)
         versionString = bundleVersion


### PR DESCRIPTION
## Description of the change

Release #35 - Make account id required.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change: account id is now required
