### PR TITLE
Release 2.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## 2.3.x Releases
+
+- `2.3.x` Releases - [2.3.10](#2310)
+
+---
+
+### 2.3.10
+
+#### Added
+
+- PinwheelEventType.inputRequired
+  - Added by [Robby Abaya](https://github.com/rawbee) in Pull Request [#50](https://github.com/underdog-tech/pinwheel-ios-sdk/pull/50).
+
+#### Updated
+
+- Move webview initialization earlier in lifecycle
+  - Added by [Robby Abaya](https://github.com/rawbee) in Pull Request [#49](https://github.com/underdog-tech/pinwheel-ios-sdk/pull/49).

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Nimble (9.0.1)
-  - PinwheelSDK (2.3.8)
+  - PinwheelSDK (2.3.10)
   - Quick (1.2.0)
 
 DEPENDENCIES:
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 7bed62ffabd6dbfe05f5925cbc43722533248990
-  PinwheelSDK: 1d618ce784ca8ae274e2ecfdb16fdd0d8d4f0b66
+  PinwheelSDK: 3f12912c5ab9d76a95c6f461f88a967cf01cf5e0
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
 
 PODFILE CHECKSUM: 2398613c0d77eaf628905b1b0cc4543ffbee0f79

--- a/PinwheelSDK.podspec
+++ b/PinwheelSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PinwheelSDK'
-  s.version          = '2.3.9'
+  s.version          = '2.3.10'
   s.summary          = 'Pinwheel iOS SDK'
   s.swift_version    = '5.0'
 

--- a/Sources/PinwheelSDK/Classes/Pinwheel.swift
+++ b/Sources/PinwheelSDK/Classes/Pinwheel.swift
@@ -219,7 +219,7 @@ private enum PinwheelEventHandler: String {
 }
 
 private func getScript(token: String, initializationTime: Int64) -> String {
-    var versionString = "2.3.9"
+    var versionString = "2.3.10"
     if let bundleVersion = Bundle(identifier: "org.cocoapods.PinwheelSDK")?.infoDictionary?["CFBundleShortVersionString"] as? String {
         print(bundleVersion)
         versionString = bundleVersion


### PR DESCRIPTION
### 2.3.10

#### Added

- PinwheelEventType.inputRequired
  - Added by [Robby Abaya](https://github.com/rawbee) in Pull Request [#50](https://github.com/underdog-tech/pinwheel-ios-sdk/pull/50).

#### Updated

- Move webview initialization earlier in lifecycle
  - Added by [Robby Abaya](https://github.com/rawbee) in Pull Request [#49](https://github.com/underdog-tech/pinwheel-ios-sdk/pull/49).