### PR TITLE
Add DD forms client events

### DIFF
--- a/Example/PinwheelSDK/LinkConfigTableViewController.swift
+++ b/Example/PinwheelSDK/LinkConfigTableViewController.swift
@@ -183,13 +183,10 @@ extension LinkConfigTableViewController: PinwheelDelegate {
             self.dismiss(animated: true)
         case .error:
             print("onEvent(name: .error")
-        }
         case .ddFormBegin:
             print("onEvent(name: .ddFormBegin")
-        }
         case .ddFormCreate:
             print("onEvent(name: .ddFormCreate")
-        }
         case .ddFormDownload:
             print("onEvent(name: .ddFormDownload")
         }

--- a/Example/PinwheelSDK/LinkConfigTableViewController.swift
+++ b/Example/PinwheelSDK/LinkConfigTableViewController.swift
@@ -184,6 +184,15 @@ extension LinkConfigTableViewController: PinwheelDelegate {
         case .error:
             print("onEvent(name: .error")
         }
+        case .ddFormBegin:
+            print("onEvent(name: .ddFormBegin")
+        }
+        case .ddFormCreate:
+            print("onEvent(name: .ddFormCreate")
+        }
+        case .ddFormDownload:
+            print("onEvent(name: .ddFormDownload")
+        }
     }
     
     func onExit(_ error: PinwheelError?) {

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -337,7 +337,7 @@ class TableOfContentsSpec: QuickSpec {
                 let message = TestMessage("ddFormCreateEventHandler", body: bodyString)
                 let pinwheelVC = PinwheelViewController(token: linkToken, delegate: delegate)
                 pinwheelVC.userContentController(userContentController, didReceive: message)
-                let payload = delegate.onEventPayload as? PinwheelDDFormCreate
+                let payload = delegate.onEventPayload as? PinwheelDDFormCreatePayload
                 expect(payload?.url).to(equal("https://www.example.com"))
             }
 

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -309,6 +309,50 @@ class TableOfContentsSpec: QuickSpec {
                 expect(payload?.message).to(equal("Uh oh"))
                 expect(payload?.pendingRetry).to(beFalse())
             }
+
+            it("onEvent is called for ddFormBegin") {
+                let delegate = PinwheelVCDelegate()
+                let userContentController = WKUserContentController()
+                let body: JSONDictionary = [
+                    "type": "PINWHEEL_EVENT",
+                    "eventName": "dd_form_begin",
+                ]
+                let message = TestMessage("ddFormBeginEventHandler", body: asString(jsonDictionary: body))
+                let pinwheelVC = PinwheelViewController(token: linkToken, delegate: delegate)
+                pinwheelVC.userContentController(userContentController, didReceive: message)
+                expect(delegate.onEventName?.rawValue).to(equal("dd_form_begin"))
+            }
+
+            it("onEvent is called for ddFormCreate") {
+                let delegate = PinwheelVCDelegate()
+                let userContentController = WKUserContentController()
+                let body: JSONDictionary = [
+                    "type": "PINWHEEL_EVENT",
+                    "eventName": "dd_form_create",
+                    "payload": [
+                        "url": "https://www.example.com",
+                    ]
+                ]
+                let bodyString = asString(jsonDictionary: body)
+                let message = TestMessage("ddFormCreateEventHandler", body: bodyString)
+                let pinwheelVC = PinwheelViewController(token: linkToken, delegate: delegate)
+                pinwheelVC.userContentController(userContentController, didReceive: message)
+                let payload = delegate.onEventPayload as? PinwheelDDFormCreate
+                expect(payload?.url).to(equal("https://www.example.com"))
+            }
+
+            it("onEvent is called for ddFormDownload") {
+                let delegate = PinwheelVCDelegate()
+                let userContentController = WKUserContentController()
+                let body: JSONDictionary = [
+                    "type": "PINWHEEL_EVENT",
+                    "eventName": "dd_form_download",
+                ]
+                let message = TestMessage("ddFormDownloadEventHandler", body: asString(jsonDictionary: body))
+                let pinwheelVC = PinwheelViewController(token: linkToken, delegate: delegate)
+                pinwheelVC.userContentController(userContentController, didReceive: message)
+                expect(delegate.onEventName?.rawValue).to(equal("dd_form_download"))
+            }
             
             it("onExit is called") {
                 let delegate = PinwheelVCDelegate()

--- a/Sources/PinwheelSDK/Classes/Events/PinwheelDDFormCreate.swift
+++ b/Sources/PinwheelSDK/Classes/Events/PinwheelDDFormCreate.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct PinwheelDDFormCreate: PinwheelEventPayload {
+    public init(url: String) {
+        self.url = url
+    }
+
+    public let url: String
+}

--- a/Sources/PinwheelSDK/Classes/Events/PinwheelDDFormCreateEvent.swift
+++ b/Sources/PinwheelSDK/Classes/Events/PinwheelDDFormCreateEvent.swift
@@ -1,9 +1,13 @@
 import Foundation
 
 public struct PinwheelDDFormCreateEvent: Codable {
-    public init(type: String, eventName: String, payload: PinwheelDDFormCreate) {
-        self.url = url
+    public init(type: String, eventName: String, payload: PinwheelDDFormCreatePayload) {
+        self.type = type
+        self.eventName = eventName
+        self.payload = payload
     }
 
-    public let url: String
+    public let type: String
+    public let eventName: String
+    public let payload: PinwheelDDFormCreatePayload
 }

--- a/Sources/PinwheelSDK/Classes/Events/PinwheelDDFormCreateEvent.swift
+++ b/Sources/PinwheelSDK/Classes/Events/PinwheelDDFormCreateEvent.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct PinwheelDDFormCreateEvent: Codable {
+    public init(type: String, eventName: String, payload: PinwheelDDFormCreate) {
+        self.url = url
+    }
+
+    public let url: String
+}

--- a/Sources/PinwheelSDK/Classes/Events/PinwheelDDFormCreatePayload.swift
+++ b/Sources/PinwheelSDK/Classes/Events/PinwheelDDFormCreatePayload.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PinwheelDDFormCreate: PinwheelEventPayload {
+public struct PinwheelDDFormCreatePayload: PinwheelEventPayload {
     public init(url: String) {
         self.url = url
     }

--- a/Sources/PinwheelSDK/Classes/Events/PinwheelEventType.swift
+++ b/Sources/PinwheelSDK/Classes/Events/PinwheelEventType.swift
@@ -20,4 +20,7 @@ public enum PinwheelEventType: String {
     case exit
     case success
     case error
+    case ddFormBegin = "dd_form_begin"
+    case ddFormCreate = "dd_form_create"
+    case ddFormDownload = "dd_form_download"
 }

--- a/Sources/PinwheelSDK/Classes/Pinwheel.swift
+++ b/Sources/PinwheelSDK/Classes/Pinwheel.swift
@@ -233,6 +233,16 @@ public class PinwheelViewController: UIViewController, WKUIDelegate, WKScriptMes
                 self.delegate?.onEvent(name: .error, event: event.payload)
                 self.delegate?.onError(event.payload)
             }
+        case PinwheelEventHandler.ddFormBeginEventHandler.rawValue:
+            self.delegate?.onEvent(name: .ddFormBegin, event: nil)
+        case PinwheelEventHandler.ddFormCreateEventHandler.rawValue:
+            if let bodyData = bodyDataFromMessage(message),
+               let event = try? JSONDecoder().decode(PinwheelDDFormCreateEvent.self, from: bodyData) {
+
+                self.delegate?.onEvent(name: .ddFormCreate, event: event.payload)
+            }
+        case PinwheelEventHandler.ddFormDownloadEventHandler.rawValue:
+            self.delegate?.onEvent(name: .ddFormDownload, event: nil)
         default:
             print("Unhandled message: \(message.name)")
         }
@@ -376,6 +386,21 @@ public class PinwheelViewController: UIViewController, WKUIDelegate, WKScriptMes
                             case "\(PinwheelEventType.error.rawValue)":
                                 if (window.webkit.messageHandlers.\(PinwheelEventHandler.errorEventHandler.rawValue)) {
                                     window.webkit.messageHandlers.\(PinwheelEventHandler.errorEventHandler.rawValue).postMessage(JSON.stringify(event.data));
+                                }
+                                break;
+                            case "\(PinwheelEventType.ddFormBegin.rawValue)":
+                                if (window.webkit.messageHandlers.\(PinwheelEventHandler.ddFormBeginEventHandler.rawValue)) {
+                                    window.webkit.messageHandlers.\(PinwheelEventHandler.ddFormBeginEventHandler.rawValue).postMessage(JSON.stringify(event.data));
+                                }
+                                break;
+                            case "\(PinwheelEventType.ddFormCreate.rawValue)":
+                                if (window.webkit.messageHandlers.\(PinwheelEventHandler.ddFormCreateEventHandler.rawValue)) {
+                                    window.webkit.messageHandlers.\(PinwheelEventHandler.ddFormCreateEventHandler.rawValue).postMessage(JSON.stringify(event.data));
+                                }
+                                break;
+                            case "\(PinwheelEventType.ddFormDownload.rawValue)":
+                                if (window.webkit.messageHandlers.\(PinwheelEventHandler.ddFormDownloadEventHandler.rawValue)) {
+                                    window.webkit.messageHandlers.\(PinwheelEventHandler.ddFormDownloadEventHandler.rawValue).postMessage(JSON.stringify(event.data));
                                 }
                                 break;
                         }

--- a/Sources/PinwheelSDK/Classes/Pinwheel.swift
+++ b/Sources/PinwheelSDK/Classes/Pinwheel.swift
@@ -464,4 +464,7 @@ private enum PinwheelEventHandler: String, CaseIterable {
     case exitEventHandler
     case successEventHandler
     case errorEventHandler
+    case ddFormBeginEventHandler
+    case ddFormCreateEventHandler
+    case ddFormDownloadEventHandler
 }


### PR DESCRIPTION
## Description of the change

Add DD forms client events:
* `dd_form_begin`
* `dd_form_create: { url: string } `
* `dd_form_download`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> [DD-310](https://pinwheel.atlassian.net/browse/DD-310)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 


[DD-310]: https://pinwheel.atlassian.net/browse/DD-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ